### PR TITLE
Extra title fix

### DIFF
--- a/HowwowKnyight/HowwowKnyightMod.cs
+++ b/HowwowKnyight/HowwowKnyightMod.cs
@@ -85,7 +85,7 @@ public sealed class HowwowKnyight():
         },
         new() {
             Name = "Main Menu",
-            Description = "Whether or not to replace the main menu title text\nThis setting will not take affect if enabled while on the main menu",
+            Description = "Whether or not to replace the main menu title text",
             Values = ["Disabled", "Enabled"],
             Loader = () => {
                 return Settings.MainMenuEnabled ? 1 : 0;

--- a/HowwowKnyight/Services/MenuTitleManager.cs
+++ b/HowwowKnyight/Services/MenuTitleManager.cs
@@ -14,6 +14,7 @@ public sealed class MenuTitleManager: IDisposable {
 
     public readonly Texture2D TitleTexture;
     public Texture2D? DebugModTitleTexture { get; private set; } = null;
+    private int? TitleIndex = null;
 
     public MenuTitleManager() {
         TitleTexture = Utils.LoadTextureFromResources(OwOTitleResourceName);
@@ -46,6 +47,7 @@ public sealed class MenuTitleManager: IDisposable {
     }
 
     private void OnSceneChange(Scene oldScene, Scene newScene) {
+        TitleIndex = null;
         RegisterStyles(newScene);
     }
 
@@ -59,19 +61,22 @@ public sealed class MenuTitleManager: IDisposable {
 
         var titleGo = scene.FindGameObject(TitleObjectName);
         var titleStyle = titleGo.GetComponent<MenuStyleTitle>();
-        titleStyle.TitleSprites = [
-            ..titleStyle.TitleSprites,
-            new() {
-                PlatformWhitelist = [.. Enum.GetValues(typeof(RuntimePlatform)).OfType<RuntimePlatform>()],
-                Default = CreateSprite(
-                    titleStyle.DefaultTitleSprite.Default,
-                    // Debug easter egg integration is currently largely untested
-                    scene.FindGameObject("DebugEasterEgg") != null
-                        ? LoadDebugTexture()
-                        : TitleTexture)
-            }
-        ];
-        titleStyle.SetTitle(titleStyle.TitleSprites.Length - 1);
+        if (TitleIndex == null) {
+            titleStyle.TitleSprites = [
+                ..titleStyle.TitleSprites,
+                new() {
+                    PlatformWhitelist = [.. Enum.GetValues(typeof(RuntimePlatform)).OfType<RuntimePlatform>()],
+                    Default = CreateSprite(
+                        titleStyle.DefaultTitleSprite.Default,
+                        // Debug easter egg integration is currently largely untested
+                        scene.FindGameObject("DebugEasterEgg") != null
+                            ? LoadDebugTexture()
+                            : TitleTexture)
+                }
+            ];
+            TitleIndex = titleStyle.TitleSprites.Length - 1;
+        }
+        titleStyle.SetTitle(TitleIndex.GetValueOrDefault());
     }
 
     public void Dispose() {

--- a/HowwowKnyight/Services/MenuTitleManager.cs
+++ b/HowwowKnyight/Services/MenuTitleManager.cs
@@ -77,6 +77,7 @@ public sealed class MenuTitleManager: IDisposable {
     public void Dispose() {
         USceneMgr.activeSceneChanged -= OnSceneChange;
         On.MenuStyles.UpdateTitle -= OnUpdateTitle;
+        ModHooks.FinishedLoadingModsHook -= OnModLoadFinished;
 
         USceneMgr.GetActiveScene()
             .FindGameObject(TitleObjectName)?


### PR DESCRIPTION
## Description
Add fixes for bugs encountered when using mod with `ExtraMenuBackgrounds`.

## Changes Made
- [x] Fix titleIndex check in `OnUpdateTitle` to actually check titleIndex and not style index
- [x] Add hook to `FinishedLoadingModsHook` as fallback for `USceneMgr.activeSceneChanged` hook being added too late
- [x] Update ModMenu text to remove notice about setting not taking affect on main menu, as `FinishedLoadingModsHook` will now result in title change attempt happening every time feature is enabled